### PR TITLE
Add script to extract the public key from the yubikey

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Host *
   IdentityAgent /usr/local/var/run/yubikey-agent.sock 
 ```
 
+## Extracting the Public Key
+
+Sometimes it might be useful to extract the public when you are on a new machine, after disaster recovery or if you
+simply misplaced it.
+In that case you can run `./extractPublicKey.sh`. Which extracts and saves the public key to your `~/.ssh` directory.
+The file will be named <yourUserName>.yubikey.pub. If such a file already exists, you will be asked if you want to
+replace it.
+
+
 ## Interactive Tools
 
 You do not need to mess with the `$SSH_AUTH_SOCK` variable, because the `IdentityAgent` setting from above

--- a/extractPublicKey.sh
+++ b/extractPublicKey.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+USERNAME=$(whoami)
+
+# stop yubikey agent - necessary to access the yubikey with pkcs
+brew services stop sandstorm-yubikey-agent
+
+# extract public key | replace string at the end with identifier > save it in ~/.ssh/
+pkcs15-tool --read-ssh-key 01 | sed -e "s/PIV AUTH pubkey/$USERNAME@YubiKey/g" > ~/.ssh/"$USERNAME".yubikey.pub
+
+# start yubikey agent again
+brew services start sandstorm-yubikey-agent

--- a/extractPublicKey.sh
+++ b/extractPublicKey.sh
@@ -5,9 +5,15 @@ FILENAME="$USERNAME".yubikey.pub
 # stop yubikey agent - necessary to access the yubikey with pkcs
 brew services stop sandstorm-yubikey-agent
 
-# extract public key | replace string at the end with identifier > save it in ~/.ssh/
+# extract public key
 pkcs15-tool --read-ssh-key 01 | sed -e "s/PIV AUTH pubkey/$USERNAME@YubiKey/g" > "$FILENAME"
+# use mv -i to avoid accidental overrides
 mv -i "$FILENAME" ~/.ssh/"$FILENAME"
+
+# clean up, in case the mv command fails
+if test -f "$FILENAME"; then
+  rm "$FILENAME"
+fi
 
 # start yubikey agent again
 brew services start sandstorm-yubikey-agent

--- a/extractPublicKey.sh
+++ b/extractPublicKey.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 USERNAME=$(whoami)
+FILENAME="$USERNAME".yubikey.pub
 
 # stop yubikey agent - necessary to access the yubikey with pkcs
 brew services stop sandstorm-yubikey-agent
 
 # extract public key | replace string at the end with identifier > save it in ~/.ssh/
-pkcs15-tool --read-ssh-key 01 | sed -e "s/PIV AUTH pubkey/$USERNAME@YubiKey/g" > ~/.ssh/"$USERNAME".yubikey.pub
+pkcs15-tool --read-ssh-key 01 | sed -e "s/PIV AUTH pubkey/$USERNAME@YubiKey/g" > "$FILENAME"
+mv -i "$FILENAME" ~/.ssh/"$FILENAME"
 
 # start yubikey agent again
 brew services start sandstorm-yubikey-agent


### PR DESCRIPTION
You might want to extract the public key again from the yubikey when using it on a new machine or after disaster recovery.

This script does just that and saves it to your ~/.ssh/ directory